### PR TITLE
Fix chmod command in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ chmod 600 $HOME/.ssh/id_rsa
 
 # Create a passphrase file
 echo "$SSH_PASSPHRASE" > $HOME/.ssh/passphrase
-chmod 600 $HOME/.ssh/id_rsa
+chmod 600 $HOME/.ssh/passphrase
 
 # Add the key with passphrase to the SSH agent
 eval $(ssh-agent -s)


### PR DESCRIPTION
Change the `chmod` command in `entrypoint.sh` to set the correct permissions for the passphrase file.

* Change `chmod` command on line 22 to `chmod 600 $HOME/.ssh/passphrase`
* Ensure the `chmod` command on line 18 remains unchanged

